### PR TITLE
Workaround sqlserver 2022-latest latest image failing (#383)

### DIFF
--- a/samples/DatabaseContainers/DatabaseContainers.AppHost/sqlserverconfig/configure-db.sh
+++ b/samples/DatabaseContainers/DatabaseContainers.AppHost/sqlserverconfig/configure-db.sh
@@ -17,7 +17,7 @@ end_by=$((start_time + 60))
 echo "Starting check for SQL Server start-up at $start_time, will end at $end_by"
 
 while [[ $SECONDS -lt $end_by && ( $errcode -ne 0 || ( -z "$dbstatus" || $dbstatus -ne 0 ) ) ]]; do
-    dbstatus="$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P "$MSSQL_SA_PASSWORD" -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases")"
+    dbstatus="$(/opt/mssql-tools18/bin/sqlcmd -h -1 -t 1 -U sa -P "$MSSQL_SA_PASSWORD" -C -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases")"
     errcode=$?
     sleep 1
 done
@@ -36,5 +36,5 @@ fi
 for f in /docker-entrypoint-initdb.d/*.sql
 do
     echo "Processing $f file..."
-    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -d master -i "$f"
+    /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C -d master -i "$f"
 done


### PR DESCRIPTION
* Workaround sqlserver 2022-latest latest image failing

.. because the path `/opt/mssql-tools/bin/sqlcmd`
changed to `/opt/mssql-tools18/bin/sqlcmd`. And this is being used in `samples/DatabaseContainers/DatabaseContainers.AppHost/sqlserverconfig/configure-db.sh`.

https://github.com/testcontainers/testcontainers-dotnet/issues/1220 https://github.com/microsoft/mssql-docker/issues/892

* Fix sqlcmd invocation to trust the server certificate

Fixes:
```
Sqlcmd: Error: Microsoft ODBC Driver 18 for SQL Server : TCP Provider: Error code 0x2749.
Sqlcmd: Error: Microsoft ODBC Driver 18 for SQL Server : SSL Provider: [error:0A000086:SSL routines::certificate verify failed:self-signed certificate].
Sqlcmd: Error: Microsoft ODBC Driver 18 for SQL Server : A network-related or instance-specific error has occurred while establishing a connection to 2d77e8a3691a. Server is not found or not accessible. Check if instance name is correct and if SQL Server is configured to allow remote connections. For more information see SQL Server Books Online..
Sqlcmd: Error: Microsoft ODBC Driver 18 for SQL Server : Client unable to establish connection. For solutions related to encryption errors, see https://go.microsoft.com/fwlink/?linkid=2226722.
```